### PR TITLE
Include reset session files in stats calculations

### DIFF
--- a/server.js
+++ b/server.js
@@ -400,7 +400,7 @@ function getSessionCost(sessionId) {
     sessionCostCache = {};
     sessionCostCacheTime = now;
     try {
-      const files = fs.readdirSync(sessDir).filter(f => f.endsWith('.jsonl'));
+      const files = fs.readdirSync(sessDir).filter(f => f.endsWith('.jsonl') || f.includes('.jsonl.reset.'));
       for (const file of files) {
         const sid = file.replace('.jsonl', '');
         let total = 0;
@@ -446,7 +446,7 @@ function getSessionsJson() {
 
 function getCostData() {
   try {
-    const files = fs.readdirSync(sessDir).filter(f => f.endsWith('.jsonl'));
+    const files = fs.readdirSync(sessDir).filter(f => f.endsWith('.jsonl') || f.includes('.jsonl.reset.'));
     const perModel = {};
     const perDay = {};
     const perSession = {};
@@ -694,7 +694,7 @@ function getUsageWindows() {
 
 function getRateLimitEvents() {
   try {
-    const files = fs.readdirSync(sessDir).filter(f => f.endsWith('.jsonl'));
+    const files = fs.readdirSync(sessDir).filter(f => f.endsWith('.jsonl') || f.includes('.jsonl.reset.'));
     const events = [];
     const now = Date.now();
     const fiveHoursMs = 5 * 3600000;
@@ -892,7 +892,7 @@ function watchSessionFile(file) {
 function startLiveWatcher() {
   if (liveWatcher) return;
   try {
-    fs.readdirSync(sessDir).filter(f => f.endsWith('.jsonl')).forEach(watchSessionFile);
+    fs.readdirSync(sessDir).filter(f => f.endsWith('.jsonl') || f.includes('.jsonl.reset.')).forEach(watchSessionFile);
     liveWatcher = fs.watch(sessDir, (eventType, filename) => {
       if (filename && filename.endsWith('.jsonl') && !_fileWatchers[filename]) {
         try { if (fs.existsSync(path.join(sessDir, filename))) watchSessionFile(filename); } catch {}
@@ -1181,7 +1181,7 @@ function buildKeyFilesAllowed() {
 
 function getTodayTokens() {
   try {
-    const files = fs.readdirSync(sessDir).filter(f => f.endsWith('.jsonl'));
+    const files = fs.readdirSync(sessDir).filter(f => f.endsWith('.jsonl') || f.includes('.jsonl.reset.'));
     const now = new Date();
     const todayStr = now.toISOString().substring(0, 10);
     const perModel = {};
@@ -1216,7 +1216,7 @@ function getTodayTokens() {
 
 function getAvgResponseTime() {
   try {
-    const files = fs.readdirSync(sessDir).filter(f => f.endsWith('.jsonl'));
+    const files = fs.readdirSync(sessDir).filter(f => f.endsWith('.jsonl') || f.includes('.jsonl.reset.'));
     const now = new Date();
     const todayStr = now.toISOString().substring(0, 10);
     const diffs = [];
@@ -1726,7 +1726,7 @@ const server = http.createServer((req, res) => {
       const sessionId = rawId.replace(/[^a-zA-Z0-9\-_:.]/g, '');
       const messages = [];
       try {
-        const files = fs.readdirSync(sessDir).filter(f => f.endsWith('.jsonl'));
+        const files = fs.readdirSync(sessDir).filter(f => f.endsWith('.jsonl') || f.includes('.jsonl.reset.'));
         let targetFile = files.find(f => f.includes(sessionId));
         if (!targetFile) {
           const sFile = path.join(sessDir, 'sessions.json');
@@ -1981,7 +1981,7 @@ const server = http.createServer((req, res) => {
           res.end(JSON.stringify(global[cacheKey]));
           return;
         }
-        const files = fs.readdirSync(sessDir).filter(f => f.endsWith('.jsonl'));
+        const files = fs.readdirSync(sessDir).filter(f => f.endsWith('.jsonl') || f.includes('.jsonl.reset.'));
         let totalTokens = 0, totalMessages = 0, totalCost = 0, totalSessions = files.length;
         let firstSessionDate = null;
         const activeDays = new Set();


### PR DESCRIPTION
Summary

- include .jsonl.reset.* files whenever the dashboard scans session data (counts, costs, usage windows, etc.)
- this means stats (tokens, daily spend, activity streaks, rate-limit history) now keep accumulating even when sessions are reset via /new or /reset
- the watcher, token tracking, and lifetime-stats endpoints now treat reset files the same as active sessions

Testing

- verified locally: dashboard now reports cumulative history even after renaming session files to *.jsonl.reset.*
- no automated tests available; change is read-only data filtering