### PR TITLE
fix(cost): infer provider from model name for custom/self-hosted providers (#30)

### DIFF
--- a/server.js
+++ b/server.js
@@ -104,13 +104,35 @@ function loadModelPricing() {
 
 const MODEL_PRICING = loadModelPricing();
 
+function inferProviderFromModel(model) {
+  const m = String(model || '').toLowerCase();
+  if (m.startsWith('claude-')) return 'anthropic';
+  if (m.startsWith('gpt-') || m.startsWith('o1') || m.startsWith('o3')) return 'openai';
+  if (m.startsWith('gemini-')) return 'google';
+  if (m.startsWith('grok-')) return 'xai';
+  return null;
+}
+
+function lookupRates(provider, modelNorm) {
+  // Exact match first
+  const rates = MODEL_PRICING[`${provider}/${modelNorm}`];
+  if (rates) return rates;
+  // For custom/unknown providers, try to infer from model name
+  const inferredProvider = inferProviderFromModel(modelNorm);
+  if (inferredProvider && inferredProvider !== provider) {
+    const inferredModelNorm = normalizeModel(inferredProvider, modelNorm);
+    return MODEL_PRICING[`${inferredProvider}/${inferredModelNorm}`] || null;
+  }
+  return null;
+}
+
 function estimateMsgCost(msg) {
   const usage = msg && msg.usage ? msg.usage : {};
   const explicit = toNum(usage.cost && usage.cost.total);
   if (explicit > 0) return explicit;
   const provider = normalizeProvider(msg && msg.provider);
   const modelNorm = normalizeModel(provider, msg && msg.model);
-  const rates = MODEL_PRICING[`${provider}/${modelNorm}`];
+  const rates = lookupRates(provider, modelNorm);
   if (!rates) return 0;
   const input = Math.max(0, toNum(usage.input)) / 1_000_000;
   const output = Math.max(0, toNum(usage.output)) / 1_000_000;
@@ -750,7 +772,7 @@ function getUsageWindows() {
       const slash = model.indexOf('/');
       const provider = slash >= 0 ? model.slice(0, slash) : 'unknown';
       const modelName = slash >= 0 ? model.slice(slash + 1) : model;
-      const rates = MODEL_PRICING[`${provider}/${modelName}`] || {};
+      const rates = lookupRates(provider, modelName) || {};
       const inputCost = (data.input || 0) / 1000000 * toNum(rates.input);
       const outputCost = (data.output || 0) / 1000000 * toNum(rates.output);
       const cacheReadCost = (data.cacheRead || 0) / 1000000 * toNum(rates.cacheRead);


### PR DESCRIPTION
## Problem

When using a self-hosted or custom API provider (e.g. `custom-10-32-86-60-4141`), cost tracking shows $0 for all sessions even though token usage is present. Fixes #30.

## Root Cause

`estimateMsgCost()` builds the pricing lookup key as `${provider}/${modelNorm}`. For custom providers, this key (e.g. `custom-10-32-86-60-4141/claude-sonnet-4-6`) never matches `DEFAULT_MODEL_PRICING`, which only contains standard provider names like `anthropic/claude-sonnet-4-6`. The function returns `0` silently.

The same gap exists in the stats endpoint (`perModelCost5h`) which uses the same direct lookup.

## Fix

Add a `lookupRates(provider, modelNorm)` helper with two lookup stages:

1. **Exact match** — same as before, zero behavior change for standard providers
2. **Model-name inference fallback** — when exact key not found, `inferProviderFromModel()` maps model families to their known providers:
   - `claude-*` → `anthropic`
   - `gpt-*` / `o1` / `o3` → `openai`
   - `gemini-*` → `google`
   - `grok-*` → `xai`

Both `estimateMsgCost()` and the stats endpoint now use `lookupRates()`.

## Testing

```
✅ standard anthropic provider: input rate = 3 (expected 3)
✅ custom provider + claude model: input rate = 3 (expected 3)
✅ custom provider + gpt model: input rate = 0.15 (expected 0.15)
✅ unknown model returns null: input rate = null (expected null)
4/4 tests passed
```

No existing behavior changes for sessions using standard provider names.