### PR TITLE
Add AI-OS command summary and trust Cloudflare Access

### DIFF
--- a/index.html
+++ b/index.html
@@ -1385,6 +1385,10 @@ body.light-theme ::selection { background: rgba(99,102,241,0.2); }
         <span class="icon">🤖</span>
         <span class="nav-text">Sessions</span>
       </div>
+      <div class="nav-item" data-page="aios">
+        <span class="icon">⚡</span>
+        <span class="nav-text">AI-OS</span>
+      </div>
       <div class="nav-item" data-page="costs">
         <span class="icon">💰</span>
         <span class="nav-text">Costs</span>
@@ -1741,6 +1745,35 @@ body.light-theme ::selection { background: rgba(99,102,241,0.2); }
           <div class="sortable" data-sort="updated">Updated</div>
         </div>
         <div id="sessionsTableBody"></div>
+      </div>
+    </div>
+
+
+    <div class="page" id="aios">
+      <div class="page-header">
+        <h1 class="page-title">AI-OS</h1>
+        <p class="page-subtitle">Persoonlijk AI Operating System — briefings, runs en operationele voortgang</p>
+      </div>
+
+      <div class="grid grid-4 mb-24">
+        <div class="card"><div class="metric accent"><div class="metric-value" id="aiosTotalRuns">0</div><div class="metric-label">Tracked Runs</div></div></div>
+        <div class="card"><div class="metric green"><div class="metric-value" id="aiosRunningRuns">0</div><div class="metric-label">Running</div></div></div>
+        <div class="card"><div class="metric"><div class="metric-value" id="aiosSuccessToday">0</div><div class="metric-label">Success Today</div></div></div>
+        <div class="card"><div class="metric"><div class="metric-value" id="aiosFailuresToday">0</div><div class="metric-label">Failures Today</div></div></div>
+      </div>
+
+      <div class="grid grid-2 mb-24" style="align-items:start;">
+        <div class="card">
+          <div style="display:flex;align-items:center;justify-content:space-between;margin-bottom:12px;gap:12px;">
+            <h3 class="card-title" style="margin:0;">Today Briefing</h3>
+            <button onclick="fetchAiosData()" style="padding:4px 10px;background:var(--bg-tertiary);color:var(--text-secondary);border:1px solid var(--border);border-radius:6px;font-size:11px;cursor:pointer;">↻ Refresh</button>
+          </div>
+          <div id="aiosTodayBriefing" style="max-height:560px;overflow-y:auto;"></div>
+        </div>
+        <div class="card">
+          <h3 class="card-title">Recent Runs</h3>
+          <div id="aiosRecentRuns" style="max-height:560px;overflow-y:auto;"></div>
+        </div>
       </div>
     </div>
 
@@ -2676,6 +2709,7 @@ function showApp() {
   fetchHealthHistory();
   fetchMemoryFiles();
   fetchKeyFiles();
+  fetchAiosData();
   checkMFAStatus();
   
   if (localStorage.getItem('usageAutoRefresh') === '1') {
@@ -2687,6 +2721,7 @@ function showApp() {
   setInterval(fetchHealthHistory, 60000);
   setInterval(fetchMemoryFiles, 30000);
   setInterval(fetchKeyFiles, 30000);
+  setInterval(fetchAiosData, 30000);
 }
 
 function showLogin() {
@@ -3217,6 +3252,7 @@ let sortBy = 'updated';
 let sortDir = 'desc';
 let selectedSessions = new Set();
 let notificationsEnabled = false;
+let aiosData = { briefings: [], runs: [], stats: {} };
 
 document.querySelectorAll('.nav-item').forEach(item => {
   item.addEventListener('click', () => {
@@ -3236,6 +3272,9 @@ document.querySelectorAll('.nav-item').forEach(item => {
     
     if (page === 'memory') {
       fetchMemoryFiles();
+    }
+    if (page === 'aios') {
+      fetchAiosData();
     }
     if (page === 'files') {
       fetchKeyFiles();
@@ -4533,6 +4572,88 @@ function renderHealthSparklines() {
   renderSparkline('ramSparkline', 'ram', 'var(--blue)');
   renderSparkline('tempSparkline', 'temp', 'var(--yellow)');
   renderSparkline('diskSparkline', 'disk', 'var(--purple)');
+}
+
+
+function escapeHtml(value) {
+  return String(value || '')
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;')
+    .replace(/'/g, '&#39;');
+}
+
+function markdownPreview(md, maxChars = 3500) {
+  const text = String(md || '').slice(0, maxChars);
+  return escapeHtml(text)
+    .replace(/^### (.+)$/gm, '<div style="font-size:14px;font-weight:700;color:var(--accent);margin:12px 0 6px;">$1</div>')
+    .replace(/^## (.+)$/gm, '<div style="font-size:16px;font-weight:700;color:var(--accent);margin:16px 0 8px;">$1</div>')
+    .replace(/^# (.+)$/gm, '<div style="font-size:18px;font-weight:700;color:var(--accent);margin:18px 0 10px;">$1</div>')
+    .replace(/\*\*(.+?)\*\*/g, '<strong style="color:var(--text-primary);font-weight:700;">$1</strong>')
+    .replace(/`([^`]+)`/g, '<code style="background:var(--bg-tertiary);padding:2px 6px;border-radius:4px;font-size:11px;">$1</code>')
+    .replace(/\n/g, '<br>');
+}
+
+async function fetchAiosData() {
+  try {
+    const res = await authFetch(API_BASE + '/api/aios');
+    aiosData = await res.json();
+    renderAiosPage();
+  } catch (e) {
+    console.error('AI-OS fetch error:', e);
+  }
+}
+
+function renderAiosPage() {
+  const stats = aiosData.stats || {};
+  const set = (id, value) => { const el = document.getElementById(id); if (el) el.textContent = value; };
+  set('aiosTotalRuns', stats.totalRuns || 0);
+  set('aiosRunningRuns', stats.running || 0);
+  set('aiosSuccessToday', stats.successToday || 0);
+  set('aiosFailuresToday', stats.failuresToday || 0);
+
+  const briefingEl = document.getElementById('aiosTodayBriefing');
+  if (briefingEl) {
+    const latest = (aiosData.briefings || [])[0];
+    if (!latest) {
+      briefingEl.innerHTML = '<div class="empty-state"><div class="empty-state-icon">🌅</div><div class="empty-state-text">Nog geen AI-OS briefing gevonden in status/aios</div></div>';
+    } else {
+      const created = latest.createdAt ? new Date(latest.createdAt).toLocaleString('nl-NL') : '--';
+      briefingEl.innerHTML = `
+        <div style="display:flex;justify-content:space-between;align-items:flex-start;gap:12px;margin-bottom:12px;">
+          <div>
+            <div style="font-weight:700;font-size:16px;margin-bottom:4px;">${escapeHtml(latest.title || latest.briefingId || 'Briefing')}</div>
+            <div style="font-size:11px;color:var(--text-muted);font-family:'JetBrains Mono',monospace;">${escapeHtml(latest.date || '')} · ${escapeHtml(created)} · ${escapeHtml(latest.status || '')}</div>
+          </div>
+          <span class="badge main">${escapeHtml(latest.type || 'briefing')}</span>
+        </div>
+        <div style="font-size:13px;line-height:1.65;color:var(--text-secondary);font-family:'Inter',sans-serif;">${markdownPreview(latest.contentMarkdown || latest.content || '')}</div>`;
+    }
+  }
+
+  const runsEl = document.getElementById('aiosRecentRuns');
+  if (runsEl) {
+    const runs = (aiosData.runs || []).slice(0, 30);
+    const colors = { running: 'var(--yellow)', success: 'var(--green)', failure: 'var(--red)', late: 'var(--orange)' };
+    const icons = { running: '🟡', success: '✅', failure: '❌', late: '⚠️' };
+    runsEl.innerHTML = runs.map(run => {
+      const status = run.status || 'unknown';
+      const ts = run.endedAt || run.startedAt || '';
+      const when = ts ? new Date(ts).toLocaleString('nl-NL') : '--';
+      const summary = run.summary || run.error || '';
+      const color = colors[status] || 'var(--text-muted)';
+      return `<div style="padding:12px 0;border-bottom:1px solid var(--border);">
+        <div style="display:flex;align-items:center;gap:8px;margin-bottom:6px;">
+          <span>${icons[status] || '⚪'}</span>
+          <span style="font-weight:700;font-size:13px;flex:1;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;">${escapeHtml(run.workflowName || run.runId)}</span>
+          <span style="font-size:10px;color:${color};font-weight:700;text-transform:uppercase;">${escapeHtml(status)}</span>
+        </div>
+        <div style="font-size:11px;color:var(--text-muted);font-family:'JetBrains Mono',monospace;margin-bottom:4px;">${escapeHtml(run.runId || '')} · ${escapeHtml(run.tool || '')} · ${escapeHtml(run.modelRoute || 'n/a')} · ${escapeHtml(when)}</div>
+        ${summary ? `<div style="font-size:12px;color:var(--text-secondary);line-height:1.45;">${escapeHtml(summary)}</div>` : ''}
+      </div>`;
+    }).join('') || '<div class="empty-state"><div class="empty-state-icon">⚡</div><div class="empty-state-text">Nog geen AI-OS runs gevonden</div></div>';
+  }
 }
 
 async function fetchNewData() {

--- a/index.html
+++ b/index.html
@@ -2340,8 +2340,10 @@ const TOKEN_KEY = 'dashboardToken';
 const TOKEN_EXPIRY_KEY = 'dashboardTokenExpiry';
 const TOKEN_LIFETIME = 24 * 60 * 60 * 1000;
 const REMEMBER_ME_LIFETIME = 3 * 60 * 60 * 1000;
+let authDisabled = false;
 
 function getStoredToken() {
+  if (authDisabled) return 'cloudflare-access';
   let token = sessionStorage.getItem(TOKEN_KEY);
   let expiry = sessionStorage.getItem(TOKEN_EXPIRY_KEY);
   
@@ -2375,6 +2377,7 @@ function setStoredToken(token, rememberMe = false) {
 }
 
 function clearStoredToken() {
+  if (authDisabled) return;
   localStorage.removeItem(TOKEN_KEY);
   localStorage.removeItem(TOKEN_EXPIRY_KEY);
   sessionStorage.removeItem(TOKEN_KEY);
@@ -2701,6 +2704,10 @@ async function handleChangePassword(event) {
 }
 
 async function handleLogout() {
+  if (authDisabled) {
+    showToast('Dashboard login is disabled; use Cloudflare Access to sign out.', 'info');
+    return;
+  }
   if (!confirm('Are you sure you want to logout?')) return;
   
   try {
@@ -2744,6 +2751,12 @@ async function checkAuth() {
   try {
     const statusRes = await fetch(API_BASE + '/api/auth/status');
     const statusData = await statusRes.json();
+    if (statusData.authDisabled) {
+      authDisabled = true;
+      if (statusData.sessionToken) setStoredToken(statusData.sessionToken, false);
+      showApp();
+      return;
+    }
     
     const token = getStoredToken();
     

--- a/index.html
+++ b/index.html
@@ -1765,6 +1765,18 @@ body.light-theme ::selection { background: rgba(99,102,241,0.2); }
       <div class="card mb-24">
         <div style="display:flex;align-items:center;justify-content:space-between;margin-bottom:12px;gap:12px;">
           <div>
+            <h3 class="card-title" style="margin:0;">Command Summary</h3>
+            <p style="margin:4px 0 0;color:var(--text-muted);font-size:12px;">Prioriteit, risico's en eerstvolgende actie uit AI-OS data.</p>
+          </div>
+          <button onclick="fetchAiosData()" style="padding:4px 10px;background:var(--bg-tertiary);color:var(--text-secondary);border:1px solid var(--border);border-radius:6px;font-size:11px;cursor:pointer;">↻ Refresh</button>
+        </div>
+        <div id="aiosExecutiveSummary" style="margin-bottom:14px;"></div>
+        <div id="aiosHighlights" style="display:grid;grid-template-columns:repeat(auto-fit,minmax(260px,1fr));gap:10px;"></div>
+      </div>
+
+      <div class="card mb-24">
+        <div style="display:flex;align-items:center;justify-content:space-between;margin-bottom:12px;gap:12px;">
+          <div>
             <h3 class="card-title" style="margin:0;">Actions & Approvals</h3>
             <p style="margin:4px 0 0;color:var(--text-muted);font-size:12px;">Open loops, Jasper approvals en concrete next actions.</p>
           </div>
@@ -4636,6 +4648,38 @@ function renderAiosPage() {
   set('aiosRunningRuns', stats.running || 0);
   set('aiosSuccessToday', stats.successToday || 0);
   set('aiosFailuresToday', stats.failuresToday || 0);
+
+  const summaryEl = document.getElementById('aiosExecutiveSummary');
+  if (summaryEl) {
+    const summary = aiosData.executiveSummary || {};
+    const posture = summary.posture || 'groen';
+    const postureColors = { groen: 'var(--green)', oranje: 'var(--yellow)', rood: 'var(--red)' };
+    summaryEl.innerHTML = `<div style="padding:14px;border:1px solid var(--border);border-left:4px solid ${postureColors[posture] || 'var(--accent)'};border-radius:10px;background:var(--bg-secondary);">
+      <div style="display:flex;gap:10px;align-items:center;margin-bottom:6px;">
+        <span style="font-size:18px;">${posture === 'rood' ? '🔴' : posture === 'oranje' ? '🟠' : '🟢'}</span>
+        <strong style="font-size:14px;color:var(--text-primary);">${escapeHtml(summary.text || 'Geen AI-OS samenvatting beschikbaar')}</strong>
+      </div>
+      <div style="font-size:12px;color:var(--text-secondary);">Aanbevolen volgende actie: <strong>${escapeHtml(summary.nextRecommendedAction || 'Geen directe actie')}</strong></div>
+    </div>`;
+  }
+
+  const highlightsEl = document.getElementById('aiosHighlights');
+  if (highlightsEl) {
+    const kindIcons = { action: '⚡', finding: '🛡️', signal: '📡', run: '🏃' };
+    const highlights = (aiosData.highlights || []).slice(0, 8);
+    highlightsEl.innerHTML = highlights.map(item => {
+      const meta = [item.kind, item.source, item.priority || item.severity || item.status].filter(Boolean).join(' · ');
+      return `<div style="padding:12px;border:1px solid var(--border);border-radius:10px;background:var(--bg-secondary);min-height:112px;">
+        <div style="display:flex;gap:8px;align-items:center;margin-bottom:6px;">
+          <span>${kindIcons[item.kind] || '•'}</span>
+          <div style="font-size:10px;color:var(--text-muted);font-family:'JetBrains Mono',monospace;text-transform:uppercase;">${escapeHtml(meta)}</div>
+          <div style="margin-left:auto;font-size:10px;color:var(--accent);font-weight:700;">${escapeHtml(String(item.score || 0))}</div>
+        </div>
+        <div style="font-weight:700;font-size:13px;line-height:1.35;margin-bottom:6px;color:var(--text-primary);">${escapeHtml(item.title || 'AI-OS highlight')}</div>
+        ${item.summary ? `<div style="font-size:12px;color:var(--text-secondary);line-height:1.45;">${escapeHtml(item.summary).slice(0, 260)}</div>` : ''}
+      </div>`;
+    }).join('') || '<div class="empty-state"><div class="empty-state-icon">✅</div><div class="empty-state-text">Geen urgente AI-OS highlights</div></div>';
+  }
 
   const actionsEl = document.getElementById('aiosActions');
   if (actionsEl) {

--- a/index.html
+++ b/index.html
@@ -1762,6 +1762,17 @@ body.light-theme ::selection { background: rgba(99,102,241,0.2); }
         <div class="card"><div class="metric"><div class="metric-value" id="aiosFailuresToday">0</div><div class="metric-label">Failures Today</div></div></div>
       </div>
 
+      <div class="card mb-24">
+        <div style="display:flex;align-items:center;justify-content:space-between;margin-bottom:12px;gap:12px;">
+          <div>
+            <h3 class="card-title" style="margin:0;">Actions & Approvals</h3>
+            <p style="margin:4px 0 0;color:var(--text-muted);font-size:12px;">Open loops, Jasper approvals en concrete next actions.</p>
+          </div>
+          <button onclick="showCreateAiosAction()" style="padding:6px 12px;background:var(--accent);color:white;border:0;border-radius:6px;font-size:12px;cursor:pointer;">+ Action</button>
+        </div>
+        <div id="aiosActions" style="display:flex;flex-direction:column;gap:10px;"></div>
+      </div>
+
       <div class="grid grid-2 mb-24" style="align-items:start;">
         <div class="card">
           <div style="display:flex;align-items:center;justify-content:space-between;margin-bottom:12px;gap:12px;">
@@ -4613,6 +4624,29 @@ function renderAiosPage() {
   set('aiosSuccessToday', stats.successToday || 0);
   set('aiosFailuresToday', stats.failuresToday || 0);
 
+  const actionsEl = document.getElementById('aiosActions');
+  if (actionsEl) {
+    const actions = (aiosData.actions || []).slice(0, 12);
+    const colors = { open: 'var(--yellow)', pending: 'var(--orange)', done: 'var(--green)', dismissed: 'var(--text-muted)' };
+    const typeIcons = { approval: '✋', decision: '🧭', task: '⚡', followup: '🔁', risk: '⚠️' };
+    actionsEl.innerHTML = actions.map(action => {
+      const status = action.status || 'open';
+      const updated = action.updatedAt ? new Date(action.updatedAt).toLocaleString('nl-NL') : '--';
+      return `<div style="padding:12px;border:1px solid var(--border);border-radius:10px;background:var(--bg-secondary);display:flex;gap:12px;align-items:flex-start;">
+        <div style="font-size:18px;line-height:1;">${typeIcons[action.type] || '⚡'}</div>
+        <div style="flex:1;min-width:0;">
+          <div style="display:flex;gap:8px;align-items:center;margin-bottom:4px;">
+            <div style="font-weight:700;font-size:13px;flex:1;overflow:hidden;text-overflow:ellipsis;white-space:nowrap;">${escapeHtml(action.title || action.actionId)}</div>
+            <span style="font-size:10px;color:${colors[status] || 'var(--text-muted)'};font-weight:700;text-transform:uppercase;">${escapeHtml(status)}</span>
+          </div>
+          ${action.description ? `<div style="font-size:12px;color:var(--text-secondary);line-height:1.45;margin-bottom:6px;">${escapeHtml(action.description)}</div>` : ''}
+          <div style="font-size:10px;color:var(--text-muted);font-family:'JetBrains Mono',monospace;">${escapeHtml(action.priority || 'normal')} · ${escapeHtml(action.owner || 'Max')} · ${escapeHtml(updated)}</div>
+        </div>
+        ${status !== 'done' ? `<button onclick="updateAiosAction('${escapeHtml(action.actionId)}','done')" style="padding:4px 8px;border:1px solid var(--border);background:var(--bg-tertiary);color:var(--text-secondary);border-radius:6px;font-size:11px;cursor:pointer;">Done</button>` : ''}
+      </div>`;
+    }).join('') || '<div class="empty-state"><div class="empty-state-icon">✅</div><div class="empty-state-text">Geen open AI-OS actions</div></div>';
+  }
+
   const briefingEl = document.getElementById('aiosTodayBriefing');
   if (briefingEl) {
     const latest = (aiosData.briefings || [])[0];
@@ -4654,6 +4688,29 @@ function renderAiosPage() {
       </div>`;
     }).join('') || '<div class="empty-state"><div class="empty-state-icon">⚡</div><div class="empty-state-text">Nog geen AI-OS runs gevonden</div></div>';
   }
+}
+
+async function showCreateAiosAction() {
+  const title = prompt('Nieuwe AI-OS action titel');
+  if (!title) return;
+  const description = prompt('Korte context / gewenste uitkomst') || '';
+  await createAiosAction({ title, description, type: 'task', status: 'open', priority: 'normal', source: 'dashboard' });
+}
+
+async function createAiosAction(action) {
+  const res = await authFetch(API_BASE + '/api/aios/actions', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(action)
+  });
+  if (!res.ok) throw new Error('Action opslaan mislukt');
+  await fetchAiosData();
+}
+
+async function updateAiosAction(actionId, status) {
+  const action = (aiosData.actions || []).find(a => a.actionId === actionId);
+  if (!action) return;
+  await createAiosAction({ ...action, status });
 }
 
 async function fetchNewData() {

--- a/server.js
+++ b/server.js
@@ -15,6 +15,9 @@ const dataDir = path.join(WORKSPACE_DIR, 'data');
 const memoryDir = path.join(WORKSPACE_DIR, 'memory');
 const memoryMdPath = path.join(WORKSPACE_DIR, 'MEMORY.md');
 const heartbeatPath = path.join(WORKSPACE_DIR, 'HEARTBEAT.md');
+const aiosDir = path.join(WORKSPACE_DIR, 'status', 'aios');
+const briefingBufferFile = path.join(WORKSPACE_DIR, 'status', 'briefing-buffer.jsonl');
+const activeTasksFile = path.join(WORKSPACE_DIR, 'status', 'active-tasks.json');
 const healthHistoryFile = path.join(dataDir, 'health-history.json');
 const AUTH_DATA_DIR = process.env.DASHBOARD_AUTH_DIR || dataDir;
 const auditLogPath = path.join(AUTH_DATA_DIR, 'audit.log');
@@ -1285,6 +1288,141 @@ function getMemoryFiles() {
   return files;
 }
 
+
+function safeReadJson(filePath, fallback) {
+  try {
+    if (!fs.existsSync(filePath)) return fallback;
+    return JSON.parse(fs.readFileSync(filePath, 'utf8'));
+  } catch {
+    return fallback;
+  }
+}
+
+function readJsonl(filePath, limit = 200) {
+  try {
+    if (!fs.existsSync(filePath)) return [];
+    const lines = fs.readFileSync(filePath, 'utf8').split('\n').filter(Boolean);
+    return lines.slice(-limit).map(line => {
+      try { return JSON.parse(line); } catch { return null; }
+    }).filter(Boolean);
+  } catch {
+    return [];
+  }
+}
+
+function getAiosBriefings() {
+  const briefings = [];
+  try {
+    if (!fs.existsSync(aiosDir)) return [];
+    const files = fs.readdirSync(aiosDir)
+      .filter(f => /^briefing-.*\.json$/.test(f))
+      .sort()
+      .reverse()
+      .slice(0, 30);
+    for (const file of files) {
+      try {
+        const fullPath = path.join(aiosDir, file);
+        const data = JSON.parse(fs.readFileSync(fullPath, 'utf8'));
+        const briefing = data.briefing || data;
+        briefings.push({
+          ...briefing,
+          file,
+          modified: fs.statSync(fullPath).mtimeMs,
+          run: data.run || null
+        });
+      } catch {}
+    }
+  } catch {}
+  return briefings;
+}
+
+function getAiosRuns() {
+  const byId = new Map();
+  const put = (run) => {
+    if (!run || !run.runId) return;
+    const prev = byId.get(run.runId);
+    const prevTs = Date.parse(prev?.endedAt || prev?.startedAt || prev?.timestamp || 0) || 0;
+    const nextTs = Date.parse(run.endedAt || run.startedAt || run.timestamp || 0) || 0;
+    if (!prev || nextTs >= prevTs) byId.set(run.runId, run);
+  };
+
+  for (const item of getAiosBriefings()) {
+    if (item.run) put(item.run);
+  }
+
+  for (const entry of readJsonl(path.join(aiosDir, 'runs.jsonl'), 500)) {
+    put(entry);
+  }
+
+  for (const entry of readJsonl(briefingBufferFile, 500)) {
+    const taskId = entry.task_id || entry.taskId;
+    if (!taskId) continue;
+    const statusMap = { started: 'running', completed: 'success', failed: 'failure', 'review-failed': 'failure', 'verify-failed': 'failure', 'waiting-for-jasper': 'late' };
+    put({
+      runId: String(taskId).startsWith('task-') ? String(taskId) : `task-${taskId}`,
+      workflowName: entry.title || String(taskId),
+      tool: entry.tool || 'OpenClaw',
+      status: statusMap[entry.status] || entry.status || 'unknown',
+      startedAt: entry.timestamp,
+      endedAt: entry.status && entry.status !== 'started' ? entry.timestamp : undefined,
+      modelRoute: entry.model || undefined,
+      summary: entry.summary || undefined,
+      error: entry.status === 'failed' ? entry.summary : undefined,
+      metadata: {
+        taskId,
+        source: 'status/briefing-buffer.jsonl',
+        rawStatus: entry.status,
+        pr: entry.pr,
+        testUrl: entry.test_url,
+        jasperAction: entry.jasper_action,
+        durationMin: entry.duration_min
+      }
+    });
+  }
+
+  const activeTasks = safeReadJson(activeTasksFile, []);
+  if (Array.isArray(activeTasks)) {
+    for (const task of activeTasks) {
+      const taskId = task.task_id || task.taskId;
+      if (!taskId) continue;
+      put({
+        runId: String(taskId).startsWith('task-') ? String(taskId) : `task-${taskId}`,
+        workflowName: task.title || String(taskId),
+        tool: task.tool || 'OpenClaw',
+        status: 'running',
+        startedAt: task.started,
+        modelRoute: task.model,
+        summary: task.project ? `Project: ${task.project}` : undefined,
+        metadata: { ...task, source: 'status/active-tasks.json' }
+      });
+    }
+  }
+
+  return Array.from(byId.values()).sort((a, b) => {
+    const bt = Date.parse(b.endedAt || b.startedAt || b.timestamp || 0) || 0;
+    const at = Date.parse(a.endedAt || a.startedAt || a.timestamp || 0) || 0;
+    return bt - at;
+  }).slice(0, 200);
+}
+
+function getAiosSummary() {
+  const runs = getAiosRuns();
+  const today = new Intl.DateTimeFormat('sv-SE', { timeZone: 'Europe/Amsterdam', year: 'numeric', month: '2-digit', day: '2-digit' }).format(new Date());
+  const todayRuns = runs.filter(r => String(r.startedAt || r.endedAt || '').slice(0, 10) === today);
+  return {
+    generatedAt: new Date().toISOString(),
+    briefings: getAiosBriefings(),
+    runs,
+    stats: {
+      totalRuns: runs.length,
+      running: runs.filter(r => r.status === 'running').length,
+      successToday: todayRuns.filter(r => r.status === 'success').length,
+      failuresToday: todayRuns.filter(r => r.status === 'failure').length,
+      latestBriefingAt: getAiosBriefings()[0]?.createdAt || null
+    }
+  };
+}
+
 function getKeyFiles() {
   const files = [];
   for (const fname of workspaceFilenames) {
@@ -1964,6 +2102,21 @@ const server = http.createServer((req, res) => {
     if (req.url === '/api/memory') {
       res.writeHead(200, { 'Content-Type': 'application/json' });
       res.end(JSON.stringify(getMemoryFiles()));
+      return;
+    }
+    if (req.url === '/api/aios') {
+      res.writeHead(200, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify(getAiosSummary()));
+      return;
+    }
+    if (req.url === '/api/aios/briefings') {
+      res.writeHead(200, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify(getAiosBriefings()));
+      return;
+    }
+    if (req.url === '/api/aios/runs') {
+      res.writeHead(200, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify(getAiosRuns()));
       return;
     }
     if (req.url === '/api/tokens-today') {

--- a/server.js
+++ b/server.js
@@ -24,6 +24,8 @@ const aiosSignalsFile = path.join(aiosDir, 'signals.jsonl');
 const aiosInfraFindingsFile = path.join(aiosDir, 'infra-findings.jsonl');
 const healthHistoryFile = path.join(dataDir, 'health-history.json');
 const AUTH_DATA_DIR = process.env.DASHBOARD_AUTH_DIR || dataDir;
+const AUTH_DISABLED = process.env.DASHBOARD_AUTH_DISABLED === 'true' || process.env.DASHBOARD_TRUST_CLOUDFLARE_ACCESS === 'true';
+const AUTH_BYPASS_TOKEN = 'cloudflare-access';
 const auditLogPath = path.join(AUTH_DATA_DIR, 'audit.log');
 const credentialsFile = path.join(AUTH_DATA_DIR, 'credentials.json');
 const mfaSecretFile = path.join(AUTH_DATA_DIR, 'mfa-secret.txt');
@@ -373,6 +375,7 @@ function httpsEnforcement(req, res) {
 }
 
 function isAuthenticated(req) {
+  if (AUTH_DISABLED) return true;
   const authHeader = req.headers.authorization;
   let token = null;
   if (authHeader && authHeader.startsWith('Bearer ')) {
@@ -404,6 +407,7 @@ function isAuthenticated(req) {
 }
 
 function requireAuth(req, res) {
+  if (AUTH_DISABLED) return true;
   const ip = getClientIP(req);
   const limitCheck = checkRateLimit(ip);
   if (limitCheck.blocked) {
@@ -1698,6 +1702,12 @@ const server = http.createServer((req, res) => {
   }
 
   if (req.url === '/api/auth/status') {
+    if (AUTH_DISABLED) {
+      setSameSiteCORS(req, res);
+      res.writeHead(200, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify({ registered: true, loggedIn: true, authDisabled: true, sessionToken: AUTH_BYPASS_TOKEN }));
+      return;
+    }
     const creds = getCredentials();
     const registered = !!creds;
     const loggedIn = isAuthenticated(req);

--- a/server.js
+++ b/server.js
@@ -18,6 +18,7 @@ const heartbeatPath = path.join(WORKSPACE_DIR, 'HEARTBEAT.md');
 const aiosDir = path.join(WORKSPACE_DIR, 'status', 'aios');
 const briefingBufferFile = path.join(WORKSPACE_DIR, 'status', 'briefing-buffer.jsonl');
 const activeTasksFile = path.join(WORKSPACE_DIR, 'status', 'active-tasks.json');
+const aiosActionsFile = path.join(aiosDir, 'actions.jsonl');
 const healthHistoryFile = path.join(dataDir, 'health-history.json');
 const AUTH_DATA_DIR = process.env.DASHBOARD_AUTH_DIR || dataDir;
 const auditLogPath = path.join(AUTH_DATA_DIR, 'audit.log');
@@ -1405,19 +1406,47 @@ function getAiosRuns() {
   }).slice(0, 200);
 }
 
+function getAiosActions() {
+  const byId = new Map();
+  for (const entry of readJsonl(aiosActionsFile, 1000)) {
+    if (!entry || !entry.actionId) continue;
+    const prev = byId.get(entry.actionId);
+    const prevTs = Date.parse(prev?.updatedAt || prev?.createdAt || 0) || 0;
+    const nextTs = Date.parse(entry.updatedAt || entry.createdAt || 0) || 0;
+    if (!prev || nextTs >= prevTs) byId.set(entry.actionId, entry);
+  }
+  return Array.from(byId.values()).sort((a, b) => {
+    const statusWeight = { open: 0, pending: 1, done: 2, dismissed: 3 };
+    const aw = statusWeight[a.status] ?? 1;
+    const bw = statusWeight[b.status] ?? 1;
+    if (aw !== bw) return aw - bw;
+    const bt = Date.parse(b.updatedAt || b.createdAt || 0) || 0;
+    const at = Date.parse(a.updatedAt || a.createdAt || 0) || 0;
+    return bt - at;
+  }).slice(0, 200);
+}
+
+function appendAiosAction(action) {
+  fs.mkdirSync(aiosDir, { recursive: true });
+  fs.appendFileSync(aiosActionsFile, JSON.stringify(action) + '\n', 'utf8');
+}
+
 function getAiosSummary() {
   const runs = getAiosRuns();
+  const actions = getAiosActions();
   const today = new Intl.DateTimeFormat('sv-SE', { timeZone: 'Europe/Amsterdam', year: 'numeric', month: '2-digit', day: '2-digit' }).format(new Date());
   const todayRuns = runs.filter(r => String(r.startedAt || r.endedAt || '').slice(0, 10) === today);
   return {
     generatedAt: new Date().toISOString(),
     briefings: getAiosBriefings(),
     runs,
+    actions,
     stats: {
       totalRuns: runs.length,
       running: runs.filter(r => r.status === 'running').length,
       successToday: todayRuns.filter(r => r.status === 'success').length,
       failuresToday: todayRuns.filter(r => r.status === 'failure').length,
+      openActions: actions.filter(a => a.status === 'open' || a.status === 'pending').length,
       latestBriefingAt: getAiosBriefings()[0]?.createdAt || null
     }
   };
@@ -2118,6 +2147,51 @@ const server = http.createServer((req, res) => {
       res.writeHead(200, { 'Content-Type': 'application/json' });
       res.end(JSON.stringify(getAiosRuns()));
       return;
+    }
+    if (req.url === '/api/aios/actions') {
+      if (req.method === 'GET') {
+        res.writeHead(200, { 'Content-Type': 'application/json' });
+        res.end(JSON.stringify(getAiosActions()));
+        return;
+      }
+      if (req.method === 'POST') {
+        let body = '';
+        req.on('data', chunk => { body += chunk; if (body.length > 8192) req.destroy(); });
+        req.on('end', () => {
+          try {
+            const input = JSON.parse(body || '{}');
+            const now = new Date().toISOString();
+            const actionId = String(input.actionId || `action-${Date.now()}-${crypto.randomBytes(3).toString('hex')}`);
+            const existing = getAiosActions().find(a => a.actionId === actionId) || {};
+            const action = {
+              ...existing,
+              actionId,
+              title: String(input.title || existing.title || '').slice(0, 160),
+              description: String(input.description || existing.description || '').slice(0, 2000),
+              type: String(input.type || existing.type || 'task').slice(0, 40),
+              status: String(input.status || existing.status || 'open').slice(0, 40),
+              priority: String(input.priority || existing.priority || 'normal').slice(0, 20),
+              owner: String(input.owner || existing.owner || 'Max').slice(0, 80),
+              source: String(input.source || existing.source || 'dashboard').slice(0, 120),
+              dueAt: input.dueAt || existing.dueAt || null,
+              createdAt: existing.createdAt || now,
+              updatedAt: now
+            };
+            if (!action.title) {
+              res.writeHead(400, { 'Content-Type': 'application/json' });
+              res.end(JSON.stringify({ error: 'title required' }));
+              return;
+            }
+            appendAiosAction(action);
+            res.writeHead(200, { 'Content-Type': 'application/json' });
+            res.end(JSON.stringify({ ok: true, action }));
+          } catch (e) {
+            res.writeHead(400, { 'Content-Type': 'application/json' });
+            res.end(JSON.stringify({ error: 'Bad request' }));
+          }
+        });
+        return;
+      }
     }
     if (req.url === '/api/tokens-today') {
       res.writeHead(200, { 'Content-Type': 'application/json' });

--- a/server.js
+++ b/server.js
@@ -1460,6 +1460,111 @@ function getAiosRawItems() { return getAiosJsonl(aiosRawItemsFile, 'itemId', 300
 function getAiosSignals() { return getAiosJsonl(aiosSignalsFile, 'signalId', 300); }
 function getAiosInfraFindings() { return getAiosJsonl(aiosInfraFindingsFile, 'findingId', 300); }
 
+
+function aiosItemTime(item) {
+  return Date.parse(item.updatedAt || item.createdAt || item.timestamp || item.startedAt || item.endedAt || 0) || 0;
+}
+
+function aiosSeverityScore(item) {
+  const sev = String(item.severity || '').toLowerCase();
+  const pri = String(item.priority || '').toLowerCase();
+  const status = String(item.status || '').toLowerCase();
+  let score = Number(item.score || 0) || 0;
+  if (sev === 'critical') score += 12;
+  else if (sev === 'high') score += 9;
+  else if (sev === 'medium') score += 5;
+  else if (sev === 'low') score += 2;
+  if (pri === 'urgent' || pri === 'high') score += 5;
+  else if (pri === 'normal') score += 2;
+  if (status === 'open' || status === 'pending' || status === 'draft' || status === 'new') score += 3;
+  return score;
+}
+
+function getAiosHighlights(actions, signals, infraFindings, runs) {
+  const highlights = [];
+  const seenTitles = new Set();
+  const addHighlight = (item) => {
+    const key = `${item.kind}:${String(item.title || '').toLowerCase().replace(/\s+/g, ' ').trim()}`;
+    if (seenTitles.has(key)) return;
+    seenTitles.add(key);
+    highlights.push(item);
+  };
+  for (const action of actions.filter(a => ['open', 'pending'].includes(String(a.status || 'open'))).slice(0, 20)) {
+    addHighlight({
+      kind: 'action',
+      title: action.title || action.actionId,
+      summary: action.description || '',
+      priority: action.priority || 'normal',
+      status: action.status || 'open',
+      source: action.source || 'ai-os',
+      createdAt: action.updatedAt || action.createdAt,
+      score: aiosSeverityScore(action),
+      actionId: action.actionId
+    });
+  }
+  for (const finding of infraFindings.filter(f => String(f.status || 'draft') !== 'done').slice(0, 20)) {
+    addHighlight({
+      kind: 'finding',
+      title: finding.title || finding.findingId,
+      summary: finding.recommendedAction || finding.summary || '',
+      severity: finding.severity || 'medium',
+      status: finding.status || 'draft',
+      source: finding.source || 'infra',
+      url: finding.url,
+      createdAt: finding.updatedAt || finding.createdAt,
+      score: aiosSeverityScore(finding),
+      findingId: finding.findingId
+    });
+  }
+  for (const signal of signals.filter(s => String(s.status || 'new') === 'new').slice(0, 30)) {
+    addHighlight({
+      kind: 'signal',
+      title: signal.title || signal.signalId,
+      summary: signal.summary || '',
+      status: signal.status || 'new',
+      source: signal.source || 'signal',
+      url: signal.url,
+      createdAt: signal.updatedAt || signal.createdAt,
+      score: aiosSeverityScore(signal),
+      signalId: signal.signalId
+    });
+  }
+  for (const run of runs.filter(r => ['failure', 'late'].includes(String(r.status || ''))).slice(0, 10)) {
+    addHighlight({
+      kind: 'run',
+      title: run.workflowName || run.runId,
+      summary: run.error || run.summary || '',
+      status: run.status,
+      source: run.tool || 'run',
+      createdAt: run.endedAt || run.startedAt,
+      score: run.status === 'failure' ? 12 : 8,
+      runId: run.runId
+    });
+  }
+  return highlights.sort((a, b) => {
+    const scoreDiff = (b.score || 0) - (a.score || 0);
+    if (scoreDiff) return scoreDiff;
+    return aiosItemTime(b) - aiosItemTime(a);
+  }).slice(0, 8);
+}
+
+function getAiosExecutiveSummary(actions, signals, infraFindings, runs) {
+  const openActions = actions.filter(a => ['open', 'pending'].includes(String(a.status || 'open')));
+  const highActions = openActions.filter(a => ['high', 'urgent'].includes(String(a.priority || '').toLowerCase()));
+  const highFindings = infraFindings.filter(f => ['critical', 'high'].includes(String(f.severity || '').toLowerCase()) && String(f.status || 'draft') !== 'done');
+  const failedRuns = runs.filter(r => ['failure', 'late'].includes(String(r.status || '')));
+  const topSignals = signals.filter(s => String(s.status || 'new') === 'new' && (Number(s.score || 0) >= 8)).length;
+  let posture = 'groen';
+  if (failedRuns.length || highFindings.length || highActions.length) posture = 'oranje';
+  if (failedRuns.length >= 2 || highActions.length >= 2) posture = 'rood';
+  const next = highActions[0]?.title || highFindings[0]?.title || (topSignals ? 'Review high-score signalen' : 'Geen directe actie nodig');
+  return {
+    posture,
+    text: `${posture.toUpperCase()}: ${openActions.length} open actions, ${highFindings.length} high findings, ${topSignals} high-score signals, ${failedRuns.length} failed/late runs.`,
+    nextRecommendedAction: next
+  };
+}
+
 function getAiosSummary() {
   const runs = getAiosRuns();
   const actions = getAiosActions();
@@ -1468,6 +1573,8 @@ function getAiosSummary() {
   const infraFindings = getAiosInfraFindings();
   const today = new Intl.DateTimeFormat('sv-SE', { timeZone: 'Europe/Amsterdam', year: 'numeric', month: '2-digit', day: '2-digit' }).format(new Date());
   const todayRuns = runs.filter(r => String(r.startedAt || r.endedAt || '').slice(0, 10) === today);
+  const highlights = getAiosHighlights(actions, signals, infraFindings, runs);
+  const executiveSummary = getAiosExecutiveSummary(actions, signals, infraFindings, runs);
   return {
     generatedAt: new Date().toISOString(),
     briefings: getAiosBriefings(),
@@ -1476,6 +1583,8 @@ function getAiosSummary() {
     rawItems,
     signals,
     infraFindings,
+    highlights,
+    executiveSummary,
     stats: {
       totalRuns: runs.length,
       running: runs.filter(r => r.status === 'running').length,

--- a/server.js
+++ b/server.js
@@ -19,6 +19,9 @@ const aiosDir = path.join(WORKSPACE_DIR, 'status', 'aios');
 const briefingBufferFile = path.join(WORKSPACE_DIR, 'status', 'briefing-buffer.jsonl');
 const activeTasksFile = path.join(WORKSPACE_DIR, 'status', 'active-tasks.json');
 const aiosActionsFile = path.join(aiosDir, 'actions.jsonl');
+const aiosRawItemsFile = path.join(aiosDir, 'raw-items.jsonl');
+const aiosSignalsFile = path.join(aiosDir, 'signals.jsonl');
+const aiosInfraFindingsFile = path.join(aiosDir, 'infra-findings.jsonl');
 const healthHistoryFile = path.join(dataDir, 'health-history.json');
 const AUTH_DATA_DIR = process.env.DASHBOARD_AUTH_DIR || dataDir;
 const auditLogPath = path.join(AUTH_DATA_DIR, 'audit.log');
@@ -1431,9 +1434,34 @@ function appendAiosAction(action) {
   fs.appendFileSync(aiosActionsFile, JSON.stringify(action) + '\n', 'utf8');
 }
 
+function getAiosJsonl(filePath, idField, limit = 200) {
+  const byId = new Map();
+  for (const entry of readJsonl(filePath, 2000)) {
+    if (!entry) continue;
+    const id = entry[idField] || entry.id || entry.url || entry.link || entry.title;
+    if (!id) continue;
+    const prev = byId.get(id);
+    const prevTs = Date.parse(prev?.updatedAt || prev?.createdAt || prev?.timestamp || 0) || 0;
+    const nextTs = Date.parse(entry.updatedAt || entry.createdAt || entry.timestamp || 0) || 0;
+    if (!prev || nextTs >= prevTs) byId.set(id, { ...entry, [idField]: String(id) });
+  }
+  return Array.from(byId.values()).sort((a, b) => {
+    const bt = Date.parse(b.updatedAt || b.createdAt || b.timestamp || 0) || 0;
+    const at = Date.parse(a.updatedAt || a.createdAt || a.timestamp || 0) || 0;
+    return bt - at;
+  }).slice(0, limit);
+}
+
+function getAiosRawItems() { return getAiosJsonl(aiosRawItemsFile, 'itemId', 300); }
+function getAiosSignals() { return getAiosJsonl(aiosSignalsFile, 'signalId', 300); }
+function getAiosInfraFindings() { return getAiosJsonl(aiosInfraFindingsFile, 'findingId', 300); }
+
 function getAiosSummary() {
   const runs = getAiosRuns();
   const actions = getAiosActions();
+  const rawItems = getAiosRawItems();
+  const signals = getAiosSignals();
+  const infraFindings = getAiosInfraFindings();
   const today = new Intl.DateTimeFormat('sv-SE', { timeZone: 'Europe/Amsterdam', year: 'numeric', month: '2-digit', day: '2-digit' }).format(new Date());
   const todayRuns = runs.filter(r => String(r.startedAt || r.endedAt || '').slice(0, 10) === today);
   return {
@@ -1441,12 +1469,18 @@ function getAiosSummary() {
     briefings: getAiosBriefings(),
     runs,
     actions,
+    rawItems,
+    signals,
+    infraFindings,
     stats: {
       totalRuns: runs.length,
       running: runs.filter(r => r.status === 'running').length,
       successToday: todayRuns.filter(r => r.status === 'success').length,
       failuresToday: todayRuns.filter(r => r.status === 'failure').length,
       openActions: actions.filter(a => a.status === 'open' || a.status === 'pending').length,
+      rawItems: rawItems.length,
+      signals: signals.length,
+      infraFindings: infraFindings.length,
       latestBriefingAt: getAiosBriefings()[0]?.createdAt || null
     }
   };
@@ -2146,6 +2180,21 @@ const server = http.createServer((req, res) => {
     if (req.url === '/api/aios/runs') {
       res.writeHead(200, { 'Content-Type': 'application/json' });
       res.end(JSON.stringify(getAiosRuns()));
+      return;
+    }
+    if (req.url === '/api/aios/raw-items') {
+      res.writeHead(200, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify(getAiosRawItems()));
+      return;
+    }
+    if (req.url === '/api/aios/signals') {
+      res.writeHead(200, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify(getAiosSignals()));
+      return;
+    }
+    if (req.url === '/api/aios/infra-findings') {
+      res.writeHead(200, { 'Content-Type': 'application/json' });
+      res.end(JSON.stringify(getAiosInfraFindings()));
       return;
     }
     if (req.url === '/api/aios/actions') {


### PR DESCRIPTION
## Summary\n- Trust Cloudflare Access as the only dashboard auth layer when configured via env flags\n- Add AI-OS Command Summary to surface posture, next action, and prioritized highlights\n- Extend /api/aios with executiveSummary and highlights\n\n## Verification\n- node --check server.js\n- Local dashboard service health OK\n- /api/auth/status returns authDisabled/loggedIn when enabled\n- /api/aios returns executiveSummary and highlights\n\nNote: live server is already updated; this PR syncs the repo.